### PR TITLE
优化: Biz包路径创建时机修改为使用时创建

### DIFF
--- a/sofa-ark-parent/core/api/src/main/java/com/alipay/sofa/ark/api/ArkClient.java
+++ b/sofa-ark-parent/core/api/src/main/java/com/alipay/sofa/ark/api/ArkClient.java
@@ -57,27 +57,13 @@ public class ArkClient {
     private static Biz               masterBiz;
     private static InjectionService  injectionService;
     private static String[]          arguments;
-    private final static File        bizInstallDirectory;
 
     private static EventAdminService eventAdminService;
 
-    static {
-        bizInstallDirectory = getBizInstallDirectory();
-    }
-
     private static File getBizInstallDirectory() {
-        File workingDir = FileUtils.createTempDir("sofa-ark");
         String configDir = ArkConfigs.getStringValue(Constants.CONFIG_INSTALL_BIZ_DIR);
-        if (!StringUtils.isEmpty(configDir)) {
-            if (!configDir.endsWith(File.separator)) {
-                configDir += File.separator;
-            }
-            workingDir = new File(configDir);
-            if (!workingDir.exists()) {
-                workingDir.mkdir();
-            }
-        }
-        return workingDir;
+        return StringUtils.isEmpty(configDir) ? FileUtils.createTempDir("sofa-ark") : FileUtils
+            .mkdir(configDir);
     }
 
     public static File createBizSaveFile(String bizName, String bizVersion, String fileSuffix) {
@@ -85,6 +71,7 @@ public class ArkClient {
         if (!StringUtils.isEmpty(fileSuffix)) {
             suffix = fileSuffix;
         }
+        File bizInstallDirectory = getBizInstallDirectory();
         return new File(bizInstallDirectory, bizName + "-" + bizVersion + "-" + suffix);
     }
 

--- a/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/FileUtils.java
+++ b/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/FileUtils.java
@@ -159,4 +159,23 @@ public class FileUtils {
             }
         }
     }
+
+    /**
+     * creates a new directory for given path
+     *
+     * @param dirPath dest path
+     * @return Dir
+     */
+    public static File mkdir(String dirPath) {
+        if (StringUtils.isEmpty(dirPath)) {
+            return null;
+        }
+        File dir = new File(dirPath);
+        if (!dir.exists()) {
+            // Recursive creation
+            dir.mkdirs();
+        }
+        return dir;
+    }
+
 }

--- a/sofa-ark-parent/core/common/src/test/java/com/alipay/sofa/ark/common/util/FileUtilsTest.java
+++ b/sofa-ark-parent/core/common/src/test/java/com/alipay/sofa/ark/common/util/FileUtilsTest.java
@@ -63,4 +63,17 @@ public class FileUtilsTest {
         File file = new File(sampleBiz.getFile());
         Assert.assertNotNull(FileUtils.unzip(file, file.getAbsolutePath() + "-unpack"));
     }
+
+    @Test
+    public void testMkdir() {
+        Assert.assertNull(FileUtils.mkdir(""));
+        // test recursive creation
+        File newDir = FileUtils.mkdir("C:\\a\\b\\c");
+        Assert.assertNotNull(newDir);
+        // test for exist path
+        Assert.assertNotNull(FileUtils.mkdir("C:\\a\\b\\c"));
+        // del the dir
+        org.apache.commons.io.FileUtils.deleteQuietly(newDir);
+    }
+
 }


### PR DESCRIPTION
### Motivation:

ArkClient中BizInstallDir仅在动态加载Biz应用时使用，但会在启动时自动创建目录，尤其是/tmp目录，可能会因为权限问题导致启动失败，所以建议改为使用时创建

### Modification:

优化: Biz包路径创建时机修改为使用时创建

### Result:

已测试。
